### PR TITLE
Change match? statement to use updated round_nearest

### DIFF
--- a/lib/cldr/number/format/compiler.ex
+++ b/lib/cldr/number/format/compiler.ex
@@ -259,7 +259,7 @@ defmodule Cldr.Number.Format.Compiler do
       :round_to_significant_digits,
       match?(%{significant_digits: %{min: 0, max: 0}}, meta)
     )
-    |> stage_if_not(:round_to_nearest, match?(%{rounding: 0}, meta))
+    |> stage_if_not(:round_to_nearest, match?(%{round_nearest: 0}, meta))
     |> stage(:set_exponent)
     |> stage(:round_fractional_digits)
     |> stage(:output_to_tuple)


### PR DESCRIPTION
I think this is required after the updates in https://github.com/elixir-cldr/cldr_numbers/blob/3bc8291ccc6bf8849bebe89c7bdf2b1296b922db/lib/cldr/number/format/compiler.ex#L262

Ran the tests and they finished cleanly but it doesn't seem to be covered by existing cases.

(consider this an issue more than a PR)