### PR TITLE
Allow `%Currency{}` struct in `Format.Options.currency`

### DIFF
--- a/lib/cldr/number/format/options.ex
+++ b/lib/cldr/number/format/options.ex
@@ -78,7 +78,7 @@ defmodule Cldr.Number.Format.Options do
   @type t :: %__MODULE__{
     locale: LanguageTag.t(),
     number_system: System.system_name(),
-    currency: Currency.code(),
+    currency: Currency.code() | Currency.t(),
     format: format(),
     currency_digits: pos_integer(),
     currency_spacing: map(),
@@ -258,6 +258,10 @@ defmodule Cldr.Number.Format.Options do
 
   def validate_option(:currency, _options, _backend, nil) do
     {:ok, nil}
+  end
+
+  def validate_option(:currency, _options, _backend, %Cldr.Currency{} = currency) do
+    {:ok, currency}
   end
 
   def validate_option(:currency, _options, _backend, currency) do


### PR DESCRIPTION
This PR is part of a series of PRs that aim to improve performance by allowing both `%Cldr.Number.Format.Options{}` structs to be passed as options in place of keyword lists, and to add support for `%Cldr.Currency{}` structs as alternative for currency codes.

https://github.com/elixir-cldr/cldr_currencies/pull/4
https://github.com/elixir-cldr/cldr_numbers/pull/18 (this PR)
https://github.com/kipcole9/money/pull/127

This PR adds support to pass a `%Cldr.Currency` struct directly, and will ensure it is accepted as a valid currency.