### PR TITLE
Fix compile error in Elixir 1.18 due to unquoting invalid AST

### DIFF
--- a/lib/cldr/number/backend/decimal_formatter.ex
+++ b/lib/cldr/number/backend/decimal_formatter.ex
@@ -75,7 +75,7 @@ defmodule Cldr.Number.Backend.Decimal.Formatter do
         def to_string(number, format, %Options{} = options) when is_binary(format) do
           Compiler.maybe_log_compile_warning(
             format,
-            unquote(config),
+            unquote(config.suppress_warnings),
             "ex_cldr_numbers: number format #{inspect(format)} is being compiled. " <>
               "For performance reasons please consider adding this format to the " <>
               "`precompile_number_formats` list in the backend configuration."

--- a/lib/cldr/number/format/compiler.ex
+++ b/lib/cldr/number/format/compiler.ex
@@ -165,8 +165,8 @@ defmodule Cldr.Number.Format.Compiler do
   # Log a warning when a number format is being compiled at
   # runtime, but only once
   @doc false
-  defmacro maybe_log_compile_warning(format, config, message) do
-    if Code.ensure_loaded?(:persistent_term) && !config.suppress_warnings do
+  defmacro maybe_log_compile_warning(format, suppress_warnings, message) do
+    if Code.ensure_loaded?(:persistent_term) && !suppress_warnings do
       quote do
         require Cldr.Macros
         Cldr.Macros.warn_once(unquote(format), unquote(message))


### PR DESCRIPTION
Fixes the issue reported [here](https://github.com/elixir-lang/elixir/issues/13976), although as mentioned in the discussion this might just be a temporary fix.